### PR TITLE
simCore::expandEnv() supports curly braces

### DIFF
--- a/SDK/simCore/String/Utils.cpp
+++ b/SDK/simCore/String/Utils.cpp
@@ -86,12 +86,26 @@ bool hasEnv(const std::string& val)
 /// Expands all known environment variable names in the given string
 std::string expandEnv(const std::string& val)
 {
+  const std::string parenStartStr("$(");
+  const std::string braceStartStr("${");
+
   std::string rv = val;
   std::string value = val;
-  size_t start = value.find("$(");
+  size_t parenStart = value.find(parenStartStr);
+  size_t braceStart = value.find(braceStartStr);
+  size_t start = parenStart;
+  std::string startStr = parenStartStr;
+  std::string endStr = ")";
+  if (braceStart < parenStart)
+  {
+    start = braceStart;
+    startStr = braceStartStr;
+    endStr = "}";
+  }
+
   while (start != std::string::npos)
   {
-    size_t end = value.find(")", start);
+    size_t end = value.find(endStr, start);
     if (end == std::string::npos)
       return rv; // not found
 
@@ -116,14 +130,25 @@ std::string expandEnv(const std::string& val)
     }
     else
     {
-      rv += "$(" + middlePart + ")";
+      rv += startStr + middlePart + endStr;
       // Search starting from after the current $ to avoid circular loop
       searchFrom = start + 1;
     }
     rv += endPart;
     // check remainder for additional envs to expand
     value = rv;
-    start = value.find("$(", searchFrom);
+
+    parenStart = value.find(parenStartStr, searchFrom);
+    braceStart = value.find(braceStartStr, searchFrom);
+    start = parenStart;
+    startStr = parenStartStr;
+    endStr = ")";
+    if (braceStart < parenStart)
+    {
+      start = braceStart;
+      startStr = braceStartStr;
+      endStr = "}";
+    }
   }
 
   return rv;

--- a/SDK/simCore/String/Utils.h
+++ b/SDK/simCore/String/Utils.h
@@ -292,7 +292,7 @@ SDKCORE_EXPORT bool hasEnv(const std::string& val);
 
 /**
  * Expands all environment variables found inside the original string.  Respects
- * environment variables in the format $(ENV)
+ * environment variables in the format $(ENV) or ${ENV}
  * @param[in ] val Input value to expand environment variables
  * @return Updated string with environment variables expanded
  */

--- a/Testing/SimCore/TokenizerTest.cpp
+++ b/Testing/SimCore/TokenizerTest.cpp
@@ -515,7 +515,6 @@ namespace
     rv += testExpandEnv("$(SIMDIS_HOME)", env("SIMDIS_HOME"));
     // Ensure no other formats work besides $()
     rv += testExpandEnv("$SIMDIS_HOME/subdir/path", "$SIMDIS_HOME/subdir/path");
-    rv += testExpandEnv("${SIMDIS_HOME}/subdir/path", "${SIMDIS_HOME}/subdir/path");
     rv += testExpandEnv("$( SIMDIS_HOME )/subdir/path", "$( SIMDIS_HOME )/subdir/path");
     rv += testExpandEnv("$(SIMDIS_HOME )/subdir/path", "$(SIMDIS_HOME )/subdir/path");
     rv += testExpandEnv("$( SIMDIS_HOME)/subdir/path", "$( SIMDIS_HOME)/subdir/path");
@@ -528,6 +527,35 @@ namespace
     rv += testExpandEnv("$(SIMDIS_HOME)/$(TEST_HOST_PLAT)/$(TEST_HOST_OS)/test", env("SIMDIS_HOME") + "//" + env("TEST_HOST_OS") + "/test");
     // Test env with both front and back slashes
     rv += testExpandEnv("$(FILE_TEST_SLASH_DIR)", env("FILE_TEST_SLASH_DIR"));
+
+    rv += testExpandEnv("${PATH", "${PATH");
+    rv += testExpandEnv("${}", "${}");
+    rv += testExpandEnv("${SIMDIS_DIR}", env("SIMDIS_DIR"));
+    rv += testExpandEnv(" ${TMP} ", std::string(" ") + env("TMP") + " ");
+    rv += testExpandEnv(" ${ENV_NO_EXIST} ", "  ");
+    rv += testExpandEnv("foo}${SIMDIS_DIR}bar", "foo}" + env("SIMDIS_DIR") + "bar");
+    rv += testExpandEnv("foo}${SIMDIS_DIR", "foo}${SIMDIS_DIR");
+    rv += testExpandEnv("${SIMDIS_HOME}", env("SIMDIS_HOME"));
+    // Ensure no other formats work besides ${}
+    rv += testExpandEnv("${ SIMDIS_HOME }/subdir/path", "${ SIMDIS_HOME }/subdir/path");
+    rv += testExpandEnv("${SIMDIS_HOME }/subdir/path", "${SIMDIS_HOME }/subdir/path");
+    rv += testExpandEnv("${ SIMDIS_HOME}/subdir/path", "${ SIMDIS_HOME}/subdir/path");
+    // Test system envs (back slashes)
+    if (env("SYSTEMROOT") != "")
+      rv += testExpandEnv("${SYSTEMROOT}/system32", env("SYSTEMROOT") + "/system32");
+    // Test multiple envs in a name
+    rv += testExpandEnv("${SIMDIS_HOME}/${TEST_HOST_ARCH}/${TEST_HOST_OS}/test", env("SIMDIS_HOME") + "/" + env("TEST_HOST_ARCH") + "/" + env("TEST_HOST_OS") + "/test");
+    // Test multiple envs in a name, including one that does not exist (review 546 case)
+    rv += testExpandEnv("${SIMDIS_HOME}/${TEST_HOST_PLAT}/${TEST_HOST_OS}/test", env("SIMDIS_HOME") + "//" + env("TEST_HOST_OS") + "/test");
+    // Test env with both front and back slashes
+    rv += testExpandEnv("${FILE_TEST_SLASH_DIR}", env("FILE_TEST_SLASH_DIR"));
+
+    // combine $() and ${}
+    rv += testExpandEnv("${SIMDIS_HOME}/$(TEST_HOST_ARCH)/${TEST_HOST_OS}/test", env("SIMDIS_HOME") + "/" + env("TEST_HOST_ARCH") + "/" + env("TEST_HOST_OS") + "/test");
+    // but don't mix and match parens and braces
+    rv += testExpandEnv("$(SIMDIS_DIR}", "$(SIMDIS_DIR}");
+    rv += testExpandEnv("${SIMDIS_DIR)", "${SIMDIS_DIR)");
+
     return rv;
   }
 


### PR DESCRIPTION
**JIRA Issue:** SIM-15345

**Description:** simCore::expandEnv() supports curly braces. Fixes SIM-15345.

**Notes:** Unit tests copy/pasted, so that all parens unit tests are mirrored by braces tests. I also added tests on lines 553-557

**Testing Performed:** unit test passes