### PR TITLE
SDK: GOG declutter priority defaults to -1, SIM-15946

### DIFF
--- a/SDK/simCore/GOG/GogShape.cpp
+++ b/SDK/simCore/GOG/GogShape.cpp
@@ -1278,7 +1278,7 @@ void Annotation::setImageFile(const std::string& imageFile)
 
 int Annotation::getPriority(double& priority) const
 {
-  priority = priority_.value_or(100.);
+  priority = priority_.value_or(-1.);
   return (priority_.has_value() ? 0 : 1);
 }
 

--- a/SDK/simVis/GOG/GogNodeInterface.cpp
+++ b/SDK/simVis/GOG/GogNodeInterface.cpp
@@ -343,7 +343,7 @@ void GogNodeInterface::setShapeObject(simCore::GOG::GogShapePtr shape)
     anno->getOutlineThickness(thickness);
     anno->getOutlineColor(outlineColor);
     setTextOutline(LoaderUtils::convertToOsgColor(outlineColor), LoaderUtils::convertToVisOutlineThickness(thickness));
-    double priority = 0.;
+    double priority = -1.;
     anno->getPriority(priority);
     setDeclutterPriority(static_cast<int>(priority));
   }

--- a/SDK/simVis/GOG/Utils.cpp
+++ b/SDK/simVis/GOG/Utils.cpp
@@ -46,7 +46,7 @@ using namespace osgEarth;
 
 namespace {
 /// Same default priority as the simData.commonPrefs.labelPrefs.priority value
-static const float DEFAULT_LABEL_PRIORITY = 100.f;
+static const float DEFAULT_LABEL_PRIORITY = -1.f;
 }
 
 //------------------------------------------------------------------------

--- a/Testing/SimCore/GogTest.cpp
+++ b/Testing/SimCore/GogTest.cpp
@@ -907,7 +907,7 @@ int testAnnotation()
       rv += SDK_ASSERT(iconFile.empty());
       double priority = 0.;
       rv += SDK_ASSERT(anno->getPriority(priority) != 0);
-      rv += SDK_ASSERT(priority == 100.);
+      rv += SDK_ASSERT(priority == -1.);
     }
   }
   shapes.clear();


### PR DESCRIPTION
**JIRA Issue:** SIM-15946

**Description:** SDK: GOG declutter priority defaults to -1

**Notes:** set the priority to -1 by default so that declutter is turned of for label GOGs that don't specify it

**Testing Performed:** loaded label GOGs with no priority specified, verified they did not declutter