### PR TITLE
Elevation Query Proxy: Fix Return Value in No-Data Case

### DIFF
--- a/SDK/simVis/ElevationQueryProxy.cpp
+++ b/SDK/simVis/ElevationQueryProxy.cpp
@@ -206,6 +206,12 @@ bool ElevationQueryProxy::getElevationFromPool_(const osgEarth::GeoPoint& point,
       lastElevation_ = sample.elevation().as(osgEarth::Units::METERS);
       lastResolution_ = sample.resolution().getValue();
     }
+    else
+    {
+      // No data; need to fail
+      lastElevation_ = NO_DATA_VALUE;
+      lastResolution_ = 0;
+    }
   }
   else // (!blocking)
   {


### PR DESCRIPTION
**Release Notes:** SDK BUGFIX: simUtil::ElevationQueryProxy (and therefore also simUtil::MousePositionManipulator::getElevation()) returns no-data correctly when querying elevation data over a region without elevation data loaded.

**JIRA Issue:** SIM-16343

**Testing Performed:** TestAltitude.py from related JIRA issue now returns 0.0 instead of the last cached altitude value, also fixing PISIMDIS::getAltitudeFromLL().