### PR TITLE
SIM-17409 simQt::AsyncCategoryCounter Now Resets Correctly

### DIFF
--- a/SDK/simQt/CategoryFilterCounter.cpp
+++ b/SDK/simQt/CategoryFilterCounter.cpp
@@ -237,11 +237,26 @@ void AsyncCategoryCounter::asyncCountEntities()
   watcher->setFuture(QtConcurrent::run(counter_, &CategoryFilterCounter::testAllCategories));
 }
 
+void AsyncCategoryCounter::reset()
+{
+  retestPending_ = false;
+  dropNextResults_ = (counter_ != nullptr);
+  objectTypes_ = simData::ALL;
+  if (nextFilter_)
+    nextFilter_->clear();
+  lastResults_.allCategories.clear();
+}
+
 void AsyncCategoryCounter::emitResults_()
 {
   // This call happens in the main thread and is the "join" for the job
-  lastResults_ = counter_->results();
-  Q_EMIT resultsReady(lastResults_);
+  if (!dropNextResults_)
+  {
+    lastResults_ = counter_->results();
+    Q_EMIT resultsReady(lastResults_);
+  }
+  else
+    dropNextResults_ = false;
 
   // just set to nullptr, the deleteLater() for watcher will do the actual delete
   counter_ = nullptr;

--- a/SDK/simQt/CategoryFilterCounter.h
+++ b/SDK/simQt/CategoryFilterCounter.h
@@ -160,6 +160,9 @@ public Q_SLOTS:
    */
   void asyncCountEntities();
 
+  /** Reset the filter counter; discard the results of any active count. */
+  void reset();
+
 Q_SIGNALS:
   /** Indicates that the asynchronous operation from testAsync() has completed. */
   void resultsReady(const simQt::CategoryCountResults& results);
@@ -170,10 +173,11 @@ private Q_SLOTS:
 
 private:
   simQt::CategoryCountResults lastResults_;
-  CategoryFilterCounter* counter_;
+  CategoryFilterCounter* counter_ = nullptr;
   std::unique_ptr<simData::CategoryFilter> nextFilter_;
-  bool retestPending_;
-  simData::ObjectType objectTypes_;
+  bool retestPending_ = false;
+  simData::ObjectType objectTypes_ = simData::ALL;
+  bool dropNextResults_ = false;
 };
 
 }

--- a/SDK/simQt/CategoryFilterWidget.cpp
+++ b/SDK/simQt/CategoryFilterWidget.cpp
@@ -774,6 +774,7 @@ void CategoryFilterWidget::setShowEntityCount(bool fl)
     connect(counter_, SIGNAL(resultsReady(simQt::CategoryCountResults)), this, SLOT(processCategoryCounts(simQt::CategoryCountResults)));
     connect(treeModel_, SIGNAL(filterChanged(simData::CategoryFilter)), counter_, SLOT(setFilter(simData::CategoryFilter)));
     connect(treeModel_, SIGNAL(rowsInserted(QModelIndex, int, int)), counter_, SLOT(asyncCountEntities()));
+    connect(treeModel_, &QAbstractItemModel::modelReset, counter_, &simQt::AsyncCategoryCounter::reset);
     counter_->setFilter(categoryFilter());
     counter_->setObjectTypes(counterObjectTypes_);
   }

--- a/SDK/simQt/CategoryTreeModel.cpp
+++ b/SDK/simQt/CategoryTreeModel.cpp
@@ -1242,6 +1242,10 @@ void CategoryTreeModel::setSettings(Settings* settings, const QString& settingsK
 
 void CategoryTreeModel::clearTree_()
 {
+  // only reset if necessary
+  if ((categories_.size() == 0) && categoryIntToItem_.empty() && filter_->isEmpty())
+    return;
+
   beginResetModel();
   categories_.deleteAll();
   categoryIntToItem_.clear();


### PR DESCRIPTION
**JIRA Issue:** SIM-17409

**Description:** The lack of a reset allowed old filter settings to be applied to a new scenario.

**Testing Performed:** Before the change I could consistently get incorrect category counts, now the counts are always correct.